### PR TITLE
Add CQRS command/query service templates and update wizard

### DIFF
--- a/src/main/java/ir/ipaam/ipaamcli/GenerateWizardCommand.java
+++ b/src/main/java/ir/ipaam/ipaamcli/GenerateWizardCommand.java
@@ -101,11 +101,17 @@ public class GenerateWizardCommand implements Callable<Integer> {
                             baseDir + "/src/main/java/" + basePackage + "/domain/model/valueobject/" + "package-info.java");
 
                     // === Application Layer ===
-                    generator.generate("service/Service.java.ftl", model,
-                            baseDir + "/src/main/java/" + basePackage + "/application/service/" + entityName + "Service.java");
+                    generator.generate("service/CommandService.java.ftl", model,
+                            baseDir + "/src/main/java/" + basePackage + "/application/service/command/" + entityName + "CommandService.java");
 
-                    generator.generate("service/ServiceImpl.java.ftl", model,
-                            baseDir + "/src/main/java/" + basePackage + "/application/service/" + entityName + "ServiceImpl.java");
+                    generator.generate("service/CommandServiceImpl.java.ftl", model,
+                            baseDir + "/src/main/java/" + basePackage + "/application/service/command/" + entityName + "CommandServiceImpl.java");
+
+                    generator.generate("service/QueryService.java.ftl", model,
+                            baseDir + "/src/main/java/" + basePackage + "/application/service/query/" + entityName + "QueryService.java");
+
+                    generator.generate("service/QueryServiceImpl.java.ftl", model,
+                            baseDir + "/src/main/java/" + basePackage + "/application/service/query/" + entityName + "QueryServiceImpl.java");
 
                     generator.generate("query/QueryHandler.java.ftl", model,
                             baseDir + "/src/main/java/" + basePackage + "/application/service/" + entityName + "QueryHandler.java");

--- a/src/main/resources/templates/service/CommandService.java.ftl
+++ b/src/main/resources/templates/service/CommandService.java.ftl
@@ -1,0 +1,13 @@
+package ${basePackage}.service.command;
+
+import ${basePackage}.model.dto.${aggregateName}Dto;
+import java.util.UUID;
+
+/**
+ * Command service interface for ${aggregateName}.
+ * Provides write operations.
+ */
+public interface ${aggregateName}CommandService {
+    ${aggregateName}Dto save(${aggregateName}Dto dto);
+    void deleteById(UUID id);
+}

--- a/src/main/resources/templates/service/CommandServiceImpl.java.ftl
+++ b/src/main/resources/templates/service/CommandServiceImpl.java.ftl
@@ -1,0 +1,36 @@
+package ${basePackage}.service.command;
+
+import ${basePackage}.model.dto.${aggregateName}Dto;
+import ${basePackage}.mapper.${aggregateName}Mapper;
+import ${basePackage}.model.entity.${aggregateName};
+import ${basePackage}.repository.${aggregateName}Repository;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+
+/**
+ * Command service implementation for ${aggregateName}.
+ */
+@Service
+public class ${aggregateName}CommandServiceImpl implements ${aggregateName}CommandService {
+
+    private final ${aggregateName}Repository repository;
+    private final ${aggregateName}Mapper mapper;
+
+    public ${aggregateName}CommandServiceImpl(${aggregateName}Repository repository,
+                                             ${aggregateName}Mapper mapper) {
+        this.repository = repository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public ${aggregateName}Dto save(${aggregateName}Dto dto) {
+        ${aggregateName} entity = mapper.toEntity(dto);
+        ${aggregateName} saved = repository.save(entity);
+        return mapper.toDto(saved);
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/resources/templates/service/QueryService.java.ftl
+++ b/src/main/resources/templates/service/QueryService.java.ftl
@@ -1,0 +1,15 @@
+package ${basePackage}.service.query;
+
+import ${basePackage}.model.dto.${aggregateName}Dto;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Query service interface for ${aggregateName}.
+ * Provides read operations.
+ */
+public interface ${aggregateName}QueryService {
+    ${aggregateName}Dto findById(UUID id);
+    List<${aggregateName}Dto> findAll();
+    List<${aggregateName}Dto> search(String keyword);
+}

--- a/src/main/resources/templates/service/QueryServiceImpl.java.ftl
+++ b/src/main/resources/templates/service/QueryServiceImpl.java.ftl
@@ -1,0 +1,46 @@
+package ${basePackage}.service.query;
+
+import ${basePackage}.model.dto.${aggregateName}Dto;
+import ${basePackage}.mapper.${aggregateName}Mapper;
+import ${basePackage}.model.entity.${aggregateName};
+import ${basePackage}.repository.${aggregateName}Repository;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+/**
+ * Query service implementation for ${aggregateName}.
+ */
+@Service
+public class ${aggregateName}QueryServiceImpl implements ${aggregateName}QueryService {
+
+    private final ${aggregateName}Repository repository;
+    private final ${aggregateName}Mapper mapper;
+
+    public ${aggregateName}QueryServiceImpl(${aggregateName}Repository repository,
+                                           ${aggregateName}Mapper mapper) {
+        this.repository = repository;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public ${aggregateName}Dto findById(UUID id) {
+        return repository.findById(id)
+                .map(mapper::toDto)
+                .orElse(null);
+    }
+
+    @Override
+    public List<${aggregateName}Dto> findAll() {
+        return repository.findAll().stream()
+                .map(mapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<${aggregateName}Dto> search(String keyword) {
+        // Placeholder search implementation
+        return findAll();
+    }
+}


### PR DESCRIPTION
## Summary
- add CommandService and QueryService interface templates
- implement CommandServiceImpl and QueryServiceImpl templates
- update GenerateWizardCommand to generate command and query services when CQRS is enabled

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c564ec630483289d4b6e8c3aaea576