### PR TITLE
Fix package-info paths in wizard

### DIFF
--- a/src/main/java/ir/ipaam/ipaamcli/GenerateWizardCommand.java
+++ b/src/main/java/ir/ipaam/ipaamcli/GenerateWizardCommand.java
@@ -86,7 +86,7 @@ public class GenerateWizardCommand implements Callable<Integer> {
                 if (cqrs) {
                     // === Domain Layer (pure Axon artifacts) ===
                     generator.generate("info/package-info.java.ftl", model,
-                            baseDir + "/src/main/java/" + basePackage + "/domain/command/" + entityName + "package-info.java");
+                            baseDir + "/src/main/java/" + basePackage + "/domain/command/" + entityName + "/package-info.java");
 
                     generator.generate("info/package-info.java.ftl", model,
                             baseDir + "/src/main/java/" + basePackage + "/domain/event/" + "package-info.java");
@@ -117,7 +117,7 @@ public class GenerateWizardCommand implements Callable<Integer> {
                             baseDir + "/src/main/java/" + basePackage + "/application/service/" + entityName + "QueryHandler.java");
 
                     generator.generate("info/package-info.java.ftl", model,
-                            baseDir + "/src/main/java/" + basePackage + "/application/workflow/" + entityName + "package-info.java");
+                            baseDir + "/src/main/java/" + basePackage + "/application/workflow/" + entityName + "/package-info.java");
 
                     // === API Layer ===
                     generator.generate("commands/CommandController.java.ftl", model,


### PR DESCRIPTION
## Summary
- ensure package-info.java files are generated inside domain command and application workflow packages

## Testing
- `mvn -q test` *(fails: Network is unreachable for parent POM)*
- `java -cp /tmp/test/bin RunWizard <<'EOF'
demo

y
n
postgres
y
order
n
n
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68c56b4bd7c0832884d7ee068aace920